### PR TITLE
 Add support for using Cloudflare AI Gateway and forwarding native Gemini API requests 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,11 @@ PORT=3000
 ADMIN_PASSWORD=123321
 # Session management
 SESSION_SECRET_KEY=abcabc
-# Cloudflare Gateway (optional)
-# Set to "1" to use default CF Gateway or provide "project-id/gateway-name" for custom Gateway
-# If not set, defaults to direct Gemini API access
+# Custom Gemini API Endpoint (optional)
+# Use this variable to specify a custom base URL for the Gemini API.
+# This is useful for proxying requests through services like Cloudflare AI Gateway.
+# If left empty or commented out, the default Google API endpoint will be used.
+# Example: CF_GATEWAY=https://gateway.ai.cloudflare.com/v1/YOUR_PROJECT_ID/YOUR_GATEWAY_NAME/google-ai-studio
 CF_GATEWAY=
 # GitHub Sync (optional)
 # GITHUB_PROJECT format must be: "username/repo-name" e.g., "username/repo-name"

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const { db } = require('./db');
 const authRoutes = require('./routes/auth');
 const adminApiRoutes = require('./routes/adminApi');
 const apiV1Routes = require('./routes/apiV1');
+const apiV1betaRoutes = require('./routes/apiV1beta'); // Import the new v1beta routes
 
 // Import middleware
 const requireAdminAuth = require('./middleware/adminAuth');
@@ -70,7 +71,8 @@ app.use('/admin', requireAdminAuth, express.static(path.join(__dirname, '..', 'p
 // --- API Routes ---
 app.use('/api', authRoutes); 
 app.use('/api/admin', requireAdminAuth, adminApiRoutes); 
-app.use('/v1', apiV1Routes); 
+app.use('/v1', apiV1Routes);
+app.use('/v1beta', apiV1betaRoutes); // Mount the new v1beta routes
 
 // --- Global Error Handler ---
 app.use((err, req, res, next) => {

--- a/src/middleware/workerAuth.js
+++ b/src/middleware/workerAuth.js
@@ -9,10 +9,17 @@ const { db } = require('../db'); // Import the database connection
  */
 async function requireWorkerAuth(req, res, next) {
     const authHeader = req.headers.authorization;
-    const workerApiKey = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
+    let workerApiKey = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
+
+    // If key not found in header, check the custom property set by workerAuthFromQuery
+    if (!workerApiKey && req.workerApiKeyFromQuery) {
+        console.log('Using Worker API Key previously found in query parameter.');
+        workerApiKey = req.workerApiKeyFromQuery;
+    }
 
     if (!workerApiKey) {
-        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY".' });
+        // If still no key after checking both header and query (via custom property)
+        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY" or as "?key=YOUR_KEY" query parameter.' });
     }
 
     try {

--- a/src/middleware/workerAuth.js
+++ b/src/middleware/workerAuth.js
@@ -8,12 +8,24 @@ const { db } = require('../db'); // Import the database connection
  * @param {import('express').NextFunction} next
  */
 async function requireWorkerAuth(req, res, next) {
+    let workerApiKey = null;
     const authHeader = req.headers.authorization;
-    const workerApiKey = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
+
+    // 1. Try Authorization header
+    if (authHeader?.startsWith('Bearer ')) {
+        workerApiKey = authHeader.substring(7);
+    }
+    // 2. Try ?key= query parameter if header not found or invalid
+    else if (req.query.key && typeof req.query.key === 'string') {
+        workerApiKey = req.query.key;
+        console.log("Worker key obtained from query parameter."); // Optional logging
+    }
 
     if (!workerApiKey) {
-        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY".' });
+        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY" or as a "key" query parameter.' });
     }
+    // Ensure workerApiKey is trimmed
+    workerApiKey = workerApiKey.trim();
 
     try {
         // Query the database to see if the key exists

--- a/src/middleware/workerAuth.js
+++ b/src/middleware/workerAuth.js
@@ -1,7 +1,8 @@
 const { db } = require('../db'); // Import the database connection
 
 /**
- * Express middleware to validate the Worker API Key provided in the Authorization header.
+ * Express middleware to validate the Worker API Key provided in the Authorization header
+ * or via a custom property set by a preceding middleware (e.g., from query param).
  * Checks against the `worker_keys` table in the database.
  * @param {import('express').Request} req
  * @param {import('express').Response} res
@@ -40,7 +41,7 @@ async function requireWorkerAuth(req, res, next) {
 
             // Key is valid, attach it to the request object for potential use later
             // (e.g., determining safety settings)
-            req.workerApiKey = workerApiKey;
+            req.workerApiKey = workerApiKey; // Attach the validated key
 
             // Proceed to the next middleware or route handler
             next();

--- a/src/middleware/workerAuth.js
+++ b/src/middleware/workerAuth.js
@@ -8,24 +8,12 @@ const { db } = require('../db'); // Import the database connection
  * @param {import('express').NextFunction} next
  */
 async function requireWorkerAuth(req, res, next) {
-    let workerApiKey = null;
     const authHeader = req.headers.authorization;
-
-    // 1. Try Authorization header
-    if (authHeader?.startsWith('Bearer ')) {
-        workerApiKey = authHeader.substring(7);
-    }
-    // 2. Try ?key= query parameter if header not found or invalid
-    else if (req.query.key && typeof req.query.key === 'string') {
-        workerApiKey = req.query.key;
-        console.log("Worker key obtained from query parameter."); // Optional logging
-    }
+    const workerApiKey = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
 
     if (!workerApiKey) {
-        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY" or as a "key" query parameter.' });
+        return res.status(401).json({ error: 'Missing API key. Provide it in the Authorization header as "Bearer YOUR_KEY".' });
     }
-    // Ensure workerApiKey is trimmed
-    workerApiKey = workerApiKey.trim();
 
     try {
         // Query the database to see if the key exists

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -60,12 +60,16 @@ router.delete('/gemini-keys/:id', async (req, res, next) => {
     }
 });
 
-// Base Gemini API URL
-const BASE_GEMINI_URL = 'https://generativelanguage.googleapis.com';
+// Base Gemini API URL - Default
+const DEFAULT_GEMINI_URL = 'https://generativelanguage.googleapis.com';
 
-// Helper to get the base URL for Gemini API
+// Helper to get the effective base URL for Gemini API, considering CF_GATEWAY env var
 function getGeminiBaseUrl() {
-    return BASE_GEMINI_URL;
+    const customGateway = process.env.CF_GATEWAY;
+    const effectiveGatewayUrl = customGateway && customGateway.trim() !== '' ? customGateway.trim().replace(/\/$/, '') : null;
+    const baseUrl = effectiveGatewayUrl || DEFAULT_GEMINI_URL;
+    // console.log(`Admin API using Gemini Base URL: ${baseUrl}`); // Optional logging
+    return baseUrl;
 }
 
 // --- Test Gemini Key --- (/api/admin/test-gemini-key)

--- a/src/routes/apiV1beta.js
+++ b/src/routes/apiV1beta.js
@@ -21,9 +21,9 @@ function getGeminiBaseUrl() {
 const workerAuthFromQuery = (req, res, next) => {
     if (!req.headers.authorization && req.query.key) {
         // Found key in query param, treat it as Worker API Key for this request
-        // Attach it for requireWorkerAuth middleware or direct use
-        req.headers.authorization = `Bearer ${req.query.key}`;
-        console.log('Using Worker API Key from query parameter.');
+        // Attach the key to a custom property on req instead of modifying headers
+        req.workerApiKeyFromQuery = req.query.key;
+        console.log('Found Worker API Key in query parameter.');
         // IMPORTANT: Remove the key from the query object so it's not forwarded
         delete req.query.key;
         // Reconstruct req.url without the key for subsequent middleware/routing

--- a/src/routes/apiV1beta.js
+++ b/src/routes/apiV1beta.js
@@ -50,8 +50,9 @@ router.all('*', async (req, res, next) => {
 
         // --- 3. Construct Target Gemini URL ---
         const baseGeminiUrl = getGeminiBaseUrl();
-        // Append the original path and query string from the /v1beta request
-        const targetUrl = `${baseGeminiUrl}/v1beta${originalPath}${originalQuery ? '?' + originalQuery : ''}`;
+        // Append ONLY the original path and query string AFTER /v1beta from the incoming request
+        // The client is expected to include /v1beta in its request path to this proxy endpoint.
+        const targetUrl = `${baseGeminiUrl}${originalPath}${originalQuery ? '?' + originalQuery : ''}`;
 
         console.log(`Proxying to target URL: ${targetUrl} with key ID: ${selectedKey.id}`);
 

--- a/src/routes/apiV1beta.js
+++ b/src/routes/apiV1beta.js
@@ -1,0 +1,155 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const requireWorkerAuth = require('../middleware/workerAuth');
+const geminiKeyService = require('../services/geminiKeyService');
+const configService = require('../services/configService'); // Needed for model lookup for key selection
+
+const router = express.Router();
+
+// Apply worker authentication middleware to all /v1beta routes
+router.use(requireWorkerAuth);
+
+// --- Helper to get the effective base URL for Gemini API ---
+function getGeminiBaseUrl() {
+    const customGateway = process.env.CF_GATEWAY;
+    const effectiveGatewayUrl = customGateway && customGateway.trim() !== '' ? customGateway.trim().replace(/\/$/, '') : null;
+    const baseUrl = effectiveGatewayUrl || 'https://generativelanguage.googleapis.com';
+    return baseUrl;
+}
+
+// --- Catch-all handler for /v1beta/* ---
+router.all('*', async (req, res, next) => {
+    const workerApiKey = req.workerApiKey; // Attached by requireWorkerAuth
+    const originalPath = req.path; // e.g., /models/gemini-pro:generateContent
+    const originalQuery = req.url.split('?')[1] || ''; // Get query string part
+    const method = req.method;
+    const requestBody = req.body; // Assumes express.json() is used
+
+    console.log(`Received /v1beta request: ${method} ${originalPath}`);
+
+    try {
+        // --- 1. Extract Model ID for Key Selection ---
+        // Attempt to extract model from path like /models/gemini-pro:action
+        const modelMatch = originalPath.match(/^\/models\/([^:]+):/);
+        const modelId = modelMatch ? modelMatch[1] : null;
+
+        if (!modelId) {
+            console.warn(`Could not extract modelId from path: ${originalPath} for key selection.`);
+            // Proceed without modelId for key selection if necessary, or return error?
+            // For now, let's proceed, getNextAvailableGeminiKey might handle null modelId
+        }
+
+        // --- 2. Get Rotated Gemini API Key ---
+        const modelsConfig = await configService.getModelsConfig(); // Fetch config for category lookup
+        const modelCategory = modelId ? modelsConfig[modelId]?.category : null;
+        const selectedKey = await geminiKeyService.getNextAvailableGeminiKey(modelId); // Pass modelId if found
+
+        if (!selectedKey) {
+            return res.status(503).json({ error: { message: "No available Gemini API Key configured or all keys are currently rate-limited/invalid.", type: "no_key_available" } });
+        }
+
+        // --- 3. Construct Target Gemini URL ---
+        const baseGeminiUrl = getGeminiBaseUrl();
+        // Append the original path and query string from the /v1beta request
+        const targetUrl = `${baseGeminiUrl}/v1beta${originalPath}${originalQuery ? '?' + originalQuery : ''}`;
+
+        console.log(`Proxying to target URL: ${targetUrl} with key ID: ${selectedKey.id}`);
+
+        // --- 4. Prepare Headers ---
+        const headersToForward = { ...req.headers };
+        // Remove headers specific to this proxy or potentially problematic
+        delete headersToForward['host'];
+        delete headersToForward['authorization']; // Remove original worker key auth
+        delete headersToForward['connection'];
+        // Add the Gemini API key
+        headersToForward['x-goog-api-key'] = selectedKey.key;
+        // Ensure content-type is present if there's a body
+        if (method !== 'GET' && method !== 'HEAD' && !headersToForward['content-type']) {
+            headersToForward['content-type'] = 'application/json'; // Default if missing
+        }
+        // Set a user-agent
+        headersToForward['user-agent'] = 'gemini-proxy-panel-node/v1beta';
+
+        // --- 5. Make the Proxied Request ---
+        const geminiResponse = await fetch(targetUrl, {
+            method: method,
+            headers: headersToForward,
+            // Only include body for relevant methods
+            body: (method !== 'GET' && method !== 'HEAD' && requestBody) ? JSON.stringify(requestBody) : undefined,
+            // Increase timeout if needed
+            // timeout: 300000
+        });
+
+        // --- 6. Handle Response ---
+        // Set headers from Gemini response to our response
+        res.status(geminiResponse.status);
+        geminiResponse.headers.forEach((value, name) => {
+            // Avoid setting headers that cause issues (e.g., transfer-encoding with streams)
+            if (name.toLowerCase() !== 'transfer-encoding' && name.toLowerCase() !== 'connection') {
+                 // Skip content-encoding if it might interfere with Express/Node handling
+                 if (name.toLowerCase() === 'content-encoding' && value === 'gzip') {
+                    console.log("Skipping content-encoding: gzip header from upstream");
+                 } else {
+                    res.setHeader(name, value);
+                 }
+            }
+        });
+        // Add custom header
+        res.setHeader('X-Proxied-By', 'gemini-proxy-panel-node/v1beta');
+        res.setHeader('X-Selected-Key-ID', selectedKey.id);
+
+        // Pipe the response body directly
+        if (geminiResponse.body) {
+            geminiResponse.body.pipe(res);
+            // Increment usage after successfully starting the stream/response
+            geminiKeyService.incrementKeyUsage(selectedKey.id, modelId, modelCategory)
+                .catch(err => console.error(`Error incrementing usage for key ${selectedKey.id} in background:`, err));
+            // Handle 429/401/403 based on status *after* sending headers
+             if (!geminiResponse.ok) {
+                 console.warn(`Gemini API returned non-OK status ${geminiResponse.status} for key ${selectedKey.id}`);
+                 if (geminiResponse.status === 429) {
+                     // Attempt to read body for error message (might fail if already piped)
+                     try {
+                         const errorBodyText = await geminiResponse.text(); // This might consume the stream
+                         geminiKeyService.handle429Error(selectedKey.id, modelCategory, modelId, errorBodyText)
+                             .catch(err => console.error(`Error handling 429 for key ${selectedKey.id} in background:`, err));
+                     } catch (e) {
+                         console.error("Could not read error body for 429 handling after piping started.");
+                         geminiKeyService.handle429Error(selectedKey.id, modelCategory, modelId, "Unknown error (could not read body)")
+                             .catch(err => console.error(`Error handling 429 for key ${selectedKey.id} in background:`, err));
+                     }
+                 } else if (geminiResponse.status === 401 || geminiResponse.status === 403) {
+                     geminiKeyService.recordKeyError(selectedKey.id, geminiResponse.status)
+                         .catch(err => console.error(`Error recording key error ${geminiResponse.status} for key ${selectedKey.id} in background:`, err));
+                 }
+             }
+
+        } else {
+            res.end();
+             // Increment usage even if no body
+             geminiKeyService.incrementKeyUsage(selectedKey.id, modelId, modelCategory)
+                .catch(err => console.error(`Error incrementing usage for key ${selectedKey.id} in background:`, err));
+             // Handle non-OK status if no body
+             if (!geminiResponse.ok) {
+                 console.warn(`Gemini API returned non-OK status ${geminiResponse.status} (no body) for key ${selectedKey.id}`);
+                 if (geminiResponse.status === 401 || geminiResponse.status === 403) {
+                     geminiKeyService.recordKeyError(selectedKey.id, geminiResponse.status)
+                         .catch(err => console.error(`Error recording key error ${geminiResponse.status} for key ${selectedKey.id} in background:`, err));
+                 }
+                 // Handle 429? Less likely without a body, but possible.
+             }
+        }
+
+    } catch (error) {
+        console.error("Error in /v1beta proxy handler:", error);
+        // Avoid sending error details if headers already sent
+        if (!res.headersSent) {
+            next(error); // Pass to global error handler
+        } else {
+            console.error("Headers already sent, cannot forward error to client.");
+            res.end(); // End the response if possible
+        }
+    }
+});
+
+module.exports = router;

--- a/src/services/geminiProxyService.js
+++ b/src/services/geminiProxyService.js
@@ -149,8 +149,8 @@ async function proxyChatCompletions(openAIRequestBody, workerApiKey, stream) {
                 const apiAction = actualStreamMode ? 'streamGenerateContent' : 'generateContent';
                 
                 // Build complete API URL using the determined BASE_GEMINI_URL
-                // Use the original requestedModelId (including -search if present) for the API call
-                const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${requestedModelId}:${apiAction}`; // Use requestedModelId
+                // Use actualModelId instead of requestedModelId with -search suffix
+                const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${actualModelId}:${apiAction}`; // BASE_GEMINI_URL is now dynamic
                 
                 const geminiRequestHeaders = {
                     'Content-Type': 'application/json',

--- a/src/services/geminiProxyService.js
+++ b/src/services/geminiProxyService.js
@@ -149,8 +149,8 @@ async function proxyChatCompletions(openAIRequestBody, workerApiKey, stream) {
                 const apiAction = actualStreamMode ? 'streamGenerateContent' : 'generateContent';
                 
                 // Build complete API URL using the determined BASE_GEMINI_URL
-                // Use actualModelId instead of requestedModelId with -search suffix
-                const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${actualModelId}:${apiAction}`; // BASE_GEMINI_URL is now dynamic
+                // Use the original requestedModelId (including -search if present) for the API call
+                const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${requestedModelId}:${apiAction}`; // Use requestedModelId
                 
                 const geminiRequestHeaders = {
                     'Content-Type': 'application/json',

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -290,9 +290,9 @@ async function handleApiV1Beta(request: Request, env: Env, ctx: ExecutionContext
 
 		// --- 3. Construct Target Gemini URL ---
 		const baseGeminiUrl = getBaseGeminiUrl(env);
-		// Append the original path and query string from the /v1beta request
-		// IMPORTANT: Gemini API uses /v1beta path prefix, ensure it's included correctly
-		const targetUrl = `${baseGeminiUrl}/v1beta${originalPath}${originalQuery}`;
+		// Append ONLY the original path and query string AFTER /v1beta from the incoming request
+		// The client is expected to include /v1beta in its request path to this proxy endpoint.
+		const targetUrl = `${baseGeminiUrl}${originalPath}${originalQuery}`;
 
 		console.log(`Proxying to target URL: ${targetUrl} with key ID: ${selectedKey.id}`);
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -818,9 +818,9 @@ async function handleV1ChatCompletions(request: Request, env: Env, ctx: Executio
 				const apiAction = actualStreamMode ? 'streamGenerateContent' : 'generateContent';
 				const querySeparator = actualStreamMode ? '?alt=sse&' : '?'; // Use alt=sse only if actually streaming to Gemini
 
-				// For -search models, use the original model name
+				// Use the original requestedModelId (including -search if present) for the API call
 				const BASE_GEMINI_URL = getBaseGeminiUrl(env); // Get dynamic base URL
-				const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${actualModelId}:${apiAction}${querySeparator}key=${selectedKey.key}`;
+				const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${requestedModelId}:${apiAction}${querySeparator}key=${selectedKey.key}`; // Use requestedModelId
 
 				const geminiRequestHeaders = new Headers();
 				geminiRequestHeaders.set('Content-Type', 'application/json');

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1273,7 +1273,6 @@ async function handleTestGeminiKey(request: Request, env: Env, ctx: ExecutionCon
 		};
 const BASE_GEMINI_URL = getBaseGeminiUrl(env); // Get dynamic base URL
 const geminiUrl = `${BASE_GEMINI_URL}/v1beta/models/${body.modelId}:generateContent?key=${apiKey}`;
-		const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${body.modelId}:generateContent?key=${apiKey}`;
 
 		const response = await fetch(geminiUrl, {
 			method: 'POST',


### PR DESCRIPTION
1. 允许通过变量CF_GATEWAY设置Cloudflare AI Gateway实现托管日志与缓存等功能
2. 允许通过接口/v1beta转发Gemini API标准的请求实现默认支持Gemini API的客户端可以无损多API Key轮询

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for Cloudflare AI Gateway by introducing a new `/api/v1beta` route to proxy requests to the Gemini API, with enhanced functionality for worker authentication and dynamic base URL configuration.

### Why are these changes being made?
These changes enable the system to forward native Gemini API calls through a configurable proxy, accommodating custom endpoints like Cloudflare AI Gateway, while supporting improved worker authentication via headers or query parameters. This approach allows for dynamic endpoint configuration and enhances API access flexibility, addressing the need for scalable and resilient API integration.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->