### PR TITLE
fix: thinkingBudget=0 was skipped due to falsy check

### DIFF
--- a/src/services/geminiProxyService.js
+++ b/src/services/geminiProxyService.js
@@ -109,7 +109,7 @@ async function proxyChatCompletions(openAIRequestBody, workerApiKey, stream, thi
                         ...(openAIRequestBody.top_p !== undefined && { topP: openAIRequestBody.top_p }),
                         ...(openAIRequestBody.max_tokens !== undefined && { maxOutputTokens: openAIRequestBody.max_tokens }),
                         ...(openAIRequestBody.stop && { stopSequences: Array.isArray(openAIRequestBody.stop) ? openAIRequestBody.stop : [openAIRequestBody.stop] }),
-                        ...(thinkingBudget && { thinkingConfig: { thinkingBudget: thinkingBudget } }),
+                        ...(thinkingBudget !== undefined && { thinkingConfig: { thinkingBudget: thinkingBudget } }),
                     },
                     ...(geminiTools && { tools: geminiTools }),
                     ...(systemInstruction && { systemInstruction: systemInstruction }),


### PR DESCRIPTION
fix for #6 
sorry for wrong check

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the condition for setting the `thinkingConfig` to check for `thinkingBudget` being undefined instead of falsy.

### Why are these changes being made?

The previous falsy check caused a value of `thinkingBudget=0` to be skipped erroneously, as 0 is considered falsy in JavaScript. This change ensures that a `thinkingBudget` of 0 will be correctly processed, improving the robustness of the configuration handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->