### PR TITLE
Add gemini proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ PORT=3000
 ADMIN_PASSWORD=123321
 # Session management
 SESSION_SECRET_KEY=abcabc
+# Gemini proxy
+GEMINI_PROXY=https://generativelanguage.googleapis.com
 # KEEPALIVE (optional)
 # Set to "1" to enable keepalive mode request
 KEEPALIVE=

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ ADMIN_PASSWORD=123321
 # Session management
 SESSION_SECRET_KEY=abcabc
 # Gemini proxy
-GEMINI_PROXY=https://generativelanguage.googleapis.com
+GEMINI_BASE_URL=https://generativelanguage.googleapis.com
 # KEEPALIVE (optional)
 # Set to "1" to enable keepalive mode request
 KEEPALIVE=

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -62,7 +62,7 @@ router.delete('/gemini-keys/:id', async (req, res, next) => {
 });
 
 // Base Gemini API URL
-const BASE_GEMINI_URL = 'https://generativelanguage.googleapis.com';
+const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL;
 // Cloudflare Gateway base path
 const CF_GATEWAY_BASE = 'https://gateway.ai.cloudflare.com/v1';
 // Project ID regex pattern - 32 character hex string

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -62,7 +62,7 @@ router.delete('/gemini-keys/:id', async (req, res, next) => {
 });
 
 // Base Gemini API URL
-const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL;
+const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com';
 // Cloudflare Gateway base path
 const CF_GATEWAY_BASE = 'https://gateway.ai.cloudflare.com/v1';
 // Project ID regex pattern - 32 character hex string

--- a/src/services/geminiProxyService.js
+++ b/src/services/geminiProxyService.js
@@ -9,7 +9,7 @@ const proxyPool = require('../utils/proxyPool'); // Import the new proxy pool mo
 
 
 // Base Gemini API URL
-const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL;
+const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com';
 // Cloudflare Gateway base path
 const CF_GATEWAY_BASE = 'https://gateway.ai.cloudflare.com/v1';
 // Project ID regex pattern - 32 character hex string

--- a/src/services/geminiProxyService.js
+++ b/src/services/geminiProxyService.js
@@ -9,7 +9,7 @@ const proxyPool = require('../utils/proxyPool'); // Import the new proxy pool mo
 
 
 // Base Gemini API URL
-const BASE_GEMINI_URL = 'https://generativelanguage.googleapis.com';
+const BASE_GEMINI_URL = process.env.GEMINI_BASE_URL;
 // Cloudflare Gateway base path
 const CF_GATEWAY_BASE = 'https://gateway.ai.cloudflare.com/v1';
 // Project ID regex pattern - 32 character hex string

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,6 +12,8 @@ export interface Env {
 	KEEPALIVE_ENABLED?: string; // Added for keepalive feature
 }
 
+const GEMINI_BASE_URL = process.env.GEMINI_BASE_URL;
+
 // --- Session Constants ---
 const SESSION_COOKIE_NAME = '__session';
 const SESSION_DURATION_SECONDS = 1 * 60 * 60; 
@@ -807,7 +809,7 @@ async function handleV1ChatCompletions(request: Request, env: Env, ctx: Executio
 				const querySeparator = actualStreamMode ? '?alt=sse&' : '?'; // Use alt=sse only if actually streaming to Gemini
 
 				// For -search models, use the original model name
-				const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${actualModelId}:${apiAction}${querySeparator}key=${selectedKey.key}`;
+				const geminiUrl = `${GEMINI_BASE_URL}/v1beta/models/${actualModelId}:${apiAction}${querySeparator}key=${selectedKey.key}`;
 
 				const geminiRequestHeaders = new Headers();
 				geminiRequestHeaders.set('Content-Type', 'application/json');
@@ -1175,7 +1177,7 @@ async function handleAdminGeminiModels(request: Request, env: Env, ctx: Executio
   // Use the available key to request Gemini models list
   try {
     // Corrected URL and authentication method (using ?key= query parameter)
-    const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models?key=${selectedKey.key}`;
+    const geminiUrl = `${GEMINI_BASE_URL}/v1beta/models?key=${selectedKey.key}`;
     const response = await fetch(geminiUrl, {
       method: 'GET',
       headers: {
@@ -1286,7 +1288,7 @@ async function handleTestGeminiKey(request: Request, env: Env, ctx: ExecutionCon
 			contents: [{ role: "user", parts: [{ text: "Hi" }] }],
 		};
 
-		const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${body.modelId}:generateContent?key=${apiKey}`;
+		const geminiUrl = `${GEMINI_BASE_URL}/v1beta/models/${body.modelId}:generateContent?key=${apiKey}`;
 
 		const response = await fetch(geminiUrl, {
 			method: 'POST',

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,7 +12,7 @@ export interface Env {
 	KEEPALIVE_ENABLED?: string; // Added for keepalive feature
 }
 
-const GEMINI_BASE_URL = process.env.GEMINI_BASE_URL;
+const GEMINI_BASE_URL = process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com';
 
 // --- Session Constants ---
 const SESSION_COOKIE_NAME = '__session';


### PR DESCRIPTION
Add gemini proxy

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a configurable base URL for the Gemini API by allowing it to be set through the `GEMINI_BASE_URL` environment variable, with a fallback to the default URL 'https://generativelanguage.googleapis.com'.

### Why are these changes being made?

The change allows greater flexibility and adaptability in different deployment environments by permitting overrides of the Gemini base URL via environment variables, catering to cases where a different Gemini endpoint is required (e.g., testing environments, custom integrations). This approach maintains the default URL if no override is provided, ensuring backward compatibility.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->